### PR TITLE
Add compose override file for deployment with external databases

### DIFF
--- a/docker-compose.external-dbs.yaml
+++ b/docker-compose.external-dbs.yaml
@@ -1,0 +1,21 @@
+# This optional compose file may be used to deploy with external databases.
+
+services:
+  db:
+    deploy:
+      replicas: 0
+
+  qdrant:
+    deploy:
+      replicas: 0
+
+  api:
+    environment:
+      - POSTGRES_HOST=${POSTGRES_HOST?Variable not set}
+      - POSTGRES_PORT=${POSTGRES_PORT?Variable not set}
+      - QDRANT_HOST=${QDRANT_HOST?Variable not set}
+      - QDRANT_PORT=${QDRANT_PORT?Variable not set}
+
+volumes:
+  seas-db-data: null
+  seas-qdrant-data: null

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -60,11 +60,13 @@ services:
     environment:
       - API_PORT=8444
       - POSTGRES_HOST=db
+      - POSTGRES_PORT=5432
       - POSTGRES_DB=${POSTGRES_DB?Variable not set}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD?Variable not set}
       - POSTGRES_USER=${POSTGRES_USER?Variable not set}
       - FIRST_USER_PASSWORD=${FIRST_USER_PASSWORD?Variable not set}
       - QDRANT_HOST=qdrant
+      - QDRANT_PORT=6333
     healthcheck:
       test: [ "CMD-SHELL", "curl -f http://localhost:8444/health" ]
       interval: 10s


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Optional Docker Compose configuration to connect the app to externally managed Postgres and Qdrant databases. The app now requires explicit host and port environment variables, preventing startup when they’re missing.
* **Chores**
  * Default port environment variables added for Postgres (5432) and Qdrant (6333) in the standard Compose setup for easier configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->