### PR TITLE
Add production overrides compose file

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ The repository contains multiple Compose files:
 - `docker-compose.cuda.yaml`: production GPU overrides
 - `docker-compose.dev-cuda.yaml`: development GPU overrides
 - `docker-compose.external-dbs.yaml`: use external Postgres and Qdrant (disables internal `db` and `qdrant` services)
+- `docker-compose.prod.yaml`: production overrides
 
 
 First, create a `.env` file in the project root with the following content:
@@ -163,7 +164,7 @@ Build and run the stack with live reload for the API:
 docker compose -f docker-compose.yaml -f docker-compose.dev.yaml up --build --watch
 
 # Development with GPU (requires NVIDIA runtime and drivers)
-docker compose -f docker-compose.yaml -f docker-compose.dev.yaml -f docker-compose.dev-cuda.yaml up --build
+docker compose -f docker-compose.yaml -f docker-compose.dev.yaml -f docker-compose.dev-cuda.yaml up --build --watch
 
 # Use external databases (external Postgres and Qdrant)
 # Update the following variables in .env file to point to the remote host
@@ -176,7 +177,7 @@ docker compose -f docker-compose.yaml -f docker-compose.dev.yaml -f docker-compo
 
 ```
 
-Services:
+Port mappings:
 
 - FastAPI backend: http://localhost:8444/docs
 - Postgres: localhost:5433
@@ -191,21 +192,24 @@ The base compose expects an existing API image (`API_IMAGE` and optional `API_TA
 ```bash
 # Build API image
 cd api
-docker build -t your-registry/seas-api:latest -f Dockerfile.cuda .
+docker build -t your-registry/seas-api:0.1.0 -f Dockerfile .
+
 # (Optional) push to registry
-# docker push your-registry/seas-api:latest
+# docker push your-registry/seas-api:0.1.0
 
 # From repo root, run with the image
 cd ..
-API_IMAGE=your-registry/seas-api API_TAG=latest ENVIRONMENT=production \
-docker compose -f docker-compose.yaml up -d --build
+API_IMAGE=your-registry/seas-api API_TAG=0.1.0 ENVIRONMENT=production \
+docker compose -f docker-compose.yaml -f docker-compose.prod.yaml up -d
 ```
 
 For GPU-enabled production (CUDA 12.6):
 
 ```bash
-API_IMAGE=your-registry/seas-api API_TAG=latest ENVIRONMENT=production \
-docker compose -f docker-compose.yaml -f docker-compose.cuda.yaml up -d --build
+docker build -t your-registry/seas-api:0.1.0-cuda -f Dockerfile.cuda .
+
+API_IMAGE=your-registry/seas-api API_TAG=0.1.0-cuda ENVIRONMENT=production \
+docker compose -f docker-compose.yaml -f docker-compose.prod.yaml -f docker-compose.cuda.yaml up -d
 ```
 
 The provided Compose files do not include the UI container by default. Deploy the UI separately. Here is an example of using `serve` for deploying static files from `ui/`:

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /app
 
 ENV PYTHONUNBUFFERED=1
 ENV HF_HUB_DISABLE_TELEMETRY=1
+ENV HF_HUB_ENABLE_HF_TRANSFER=1
 
 # disable tokenizers parallelism to avoid overloading the CPU
 ENV TOKENIZERS_PARALLELISM=false

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -38,6 +38,8 @@ services:
       context: ./api
       dockerfile: Dockerfile
     restart: "no"
+    ports:
+      - "8444:8444"
     environment:
       - SMTP_TLS=false
       - SMTP_SSL=false

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -1,0 +1,14 @@
+# This compose file overrides the default compose file for production
+
+services:
+  qdrant:
+    ports:
+      - "6333:6333" # REST API
+
+  adminer:
+    ports:
+      - "8555:8080"
+
+  api:
+    ports:
+      - "8444:8444"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,8 +1,4 @@
 # Base compose file
-# Run this compose file with the following command:
-# ```bash
-# docker compose -f docker-compose.yaml up --build
-# ```
 
 services:
   db:
@@ -53,8 +49,6 @@ services:
   api:
     image: "${API_IMAGE}:${API_TAG-latest}"
     restart: always
-    ports:
-      - "8444:8444"
     env_file:
       - .env
     environment:
@@ -67,6 +61,7 @@ services:
       - FIRST_USER_PASSWORD=${FIRST_USER_PASSWORD?Variable not set}
       - QDRANT_HOST=qdrant
       - QDRANT_PORT=6333
+      - ENVIRONMENT=${ENVIRONMENT:-production}
     healthcheck:
       test: [ "CMD-SHELL", "curl -f http://localhost:8444/health" ]
       interval: 10s


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced a production Docker Compose override with explicit port mappings (API 8444, vector DB 6333, admin UI 8555).
  - Development setup now exposes the API on port 8444.
  - Base setup no longer exposes the API by default; use dev/prod overrides as needed.

- Documentation
  - Updated Compose usage, image tags (0.1.0 / 0.1.0-cuda), and GPU/dev commands (including watch mode).

- Chores
  - Default runtime environment set to production.
  - Enabled optimized model transfer to speed up downloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->