### PR TITLE
feat(ui): handle onclick on logo and add icon for expanding sidebar

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -41,7 +41,9 @@ reviews:
     ignore_title_keywords: []
     labels: []
     drafts: false
-    base_branches: []
+    base_branches:
+      - main
+      - dev
   finishing_touches:
     docstrings:
       enabled: true

--- a/ui/src/components/chat/Chat.tsx
+++ b/ui/src/components/chat/Chat.tsx
@@ -1,6 +1,7 @@
 import { ChatsService } from '@/client';
 import { ChatContainer } from '@/components/chat/ChatContainer';
 import { UserControls } from '@/components/chat/UserControls';
+import { SeasLogo } from '@/components/icons';
 import { Sidebar } from '@/components/layout/Sidebar';
 import { Loading } from '@/components/ui/loading';
 import { LOCAL_STORAGE_KEYS } from '@/constants/localStorageKeys';
@@ -187,7 +188,7 @@ export function Chat() {
           </button>
         </div>
         <div className="flex-1 flex items-center justify-center">
-          <span className="text-lg font-semibold text-primary">SEAS</span>
+          <SeasLogo size={28} className="text-primary" />
         </div>
         <div className="flex items-center gap-3">
           <UserControls inline />

--- a/ui/src/components/layout/Sidebar.tsx
+++ b/ui/src/components/layout/Sidebar.tsx
@@ -12,6 +12,7 @@ import { useLanguage } from '@/hooks/useLanguage';
 import {
   IconAlertCircle,
   IconChevronLeft,
+  IconChevronsRight,
   IconDots,
   IconEdit,
   IconMessage,
@@ -86,6 +87,9 @@ const SidebarHeader: React.FC<SidebarHeaderProps> = ({
   onClose,
 }) => {
   const { t } = useLanguage();
+  const handleLogoClick = () => {
+    window.location.href = '/';
+  };
 
   return (
     <div className="flex items-center justify-between p-4">
@@ -93,14 +97,21 @@ const SidebarHeader: React.FC<SidebarHeaderProps> = ({
         <Button
           variant="ghost"
           size="icon"
-          onClick={isCollapsed ? onToggle : undefined}
-          className={`h-6 w-6 rounded-md text-primary hover:text-primary/80 ${isCollapsed ? 'cursor-pointer' : 'cursor-default'}`}
-          title={isCollapsed ? t('sidebar.openSidebar') : 'SEAS'}
+          onClick={handleLogoClick}
+          className={`h-6 w-6 rounded-md text-primary hover:text-primary/80 cursor-pointer`}
+          title={'SEAS'}
         >
           <SeasLogo size={32} className="text-primary" />
         </Button>
         {!isCollapsed && (
-          <span className="text-lg font-semibold text-primary">SEAS</span>
+          <button
+            type="button"
+            onClick={handleLogoClick}
+            className="text-lg font-semibold text-primary cursor-pointer"
+            title="SEAS"
+          >
+            SEAS
+          </button>
         )}
       </div>
       {!isCollapsed && (
@@ -582,6 +593,21 @@ export const Sidebar: React.FC<SidebarProps> = ({
         onToggle={toggleSidebar}
         onClose={onRequestClose}
       />
+
+      {effectiveCollapsed && (
+        <div className="px-2">
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={toggleSidebar}
+            className="rounded-lg text-gray-700 dark:text-gray-300 cursor-pointer"
+            aria-label={t('sidebar.expandSidebar')}
+            title={t('sidebar.expandSidebar')}
+          >
+            <IconChevronsRight size={20} />
+          </Button>
+        </div>
+      )}
 
       <ActionButtons
         isCollapsed={effectiveCollapsed}

--- a/ui/src/locales/en/common.json
+++ b/ui/src/locales/en/common.json
@@ -121,6 +121,7 @@
     "history": "History",
     "openSidebar": "Open Sidebar",
     "collapseSidebar": "Collapse Sidebar",
+    "expandSidebar": "Expand Sidebar",
     "newChat": "New Chat",
     "rename": "Rename",
     "sessionName": "Session name",

--- a/ui/src/locales/vi/common.json
+++ b/ui/src/locales/vi/common.json
@@ -121,6 +121,7 @@
     "history": "Lịch sử",
     "openSidebar": "Mở thanh bên",
     "collapseSidebar": "Thu gọn thanh bên",
+    "expandSidebar": "Mở rộng thanh bên",
     "newChat": "Phiên trò chuyện mới",
     "rename": "Đổi tên",
     "sessionName": "Tên phiên",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added expand button when the sidebar is collapsed, with tooltip and accessibility labels.
  - Sidebar header/logo is now consistently clickable to return to Home.
- UI/Style
  - Replaced mobile chat header text with a branded logo.
- Localization
  - Added “Expand Sidebar” translations in English and Vietnamese.
- Chores
  - Updated automated review base branches configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->